### PR TITLE
[php7-pthreads-v3] Resolve 'CompressBatchedTask'-related crashes

### DIFF
--- a/src/pocketmine/network/CompressBatchedTask.php
+++ b/src/pocketmine/network/CompressBatchedTask.php
@@ -29,7 +29,8 @@ class CompressBatchedTask extends AsyncTask{
 	public $level = 7;
 	public $data;
 	public $final;
-	public $targets = [];
+	/** @var \Volatile $targets */
+	public $targets;
 
 	public function __construct($data, array $targets, $level = 7){
 		$this->data = $data;
@@ -47,6 +48,6 @@ class CompressBatchedTask extends AsyncTask{
 	}
 
 	public function onCompletion(Server $server){
-		$server->broadcastPacketsCallback($this->final, $this->targets);
+		$server->broadcastPacketsCallback($this->final, (array) $this->targets);
 	}
 }


### PR DESCRIPTION
Since **pthreads v3 (php7)** forces arrays to be converted to ```\Volatile``` objects when they are set as the members of ```\Threaded```, I think ```$this->targets``` needs to be explicitly converted to ```array```.